### PR TITLE
Add info about .desktop file in linux quickstart

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -28,7 +28,7 @@ description: 'After downloading Wave, get up and running quickly'
     ```
     Run `desktop-file-validate Wave.desktop` to validate that the desktop entry is correct, then run `sudo cp Wave.desktop ~/.local/share/applications/Wave.desktop` to copy the entry into your application list.
     After restarting your desktop environment (or your computer), Wave should be visible in application list, and should be launched by clicking the icon.
-    While these files and the file scheme is supported by most commonly used desktop environments such as Gnome, Kde, xfce etc. If you come across any issues, please consider opening an issue on the github repository.
+    The `.desktop` file scheme is supported by most commonly used desktop environments such as GNOME, KDE, XFCE, etc. If encounter issues, please consider opening an issue on the GitHub repository.
   </Accordion>
 </AccordionGroup>
 

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -16,7 +16,7 @@ description: 'After downloading Wave, get up and running quickly'
     3. Run the application:  ```./Wave```
     
     While we work on improving the packaging for Linux, you can optionally create a `.desktop` file, allowing you to launch Wave directly.
-    After doing the above steps, create a file named ```Wave.desktop```, and add the following :
+    After doing the above steps, create a file named `Wave.desktop`, and add the following, modifying the `Exec` path to point to your Wave installation:
     ```
     [Desktop Entry]
     Type=Application

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -22,7 +22,7 @@ description: 'After downloading Wave, get up and running quickly'
     Type=Application
     Name=Wave
     Icon= # IMP todo after PR discussion
-    Exec=/path/to/Wave-linux-x64/Wave
+    Exec=/path/to/Wave-linux-*/Wave
     # setting this to true will launch an extra terminal to run the Wave command
     Terminal=false
     ```

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -27,7 +27,7 @@ description: 'After downloading Wave, get up and running quickly'
     Terminal=false
     ```
     Run `desktop-file-validate Wave.desktop` to validate that the desktop entry is correct, then run `sudo cp Wave.desktop ~/.local/share/applications/Wave.desktop` to copy the entry into your application list.
-    After restarting, Wave should be visible in application list, and should be launched by clicking the icon.
+    After restarting your desktop environment (or your computer), Wave should be visible in application list, and should be launched by clicking the icon.
     While these files and the file scheme is supported by most commonly used desktop environments such as Gnome, Kde, xfce etc. If you come across any issues, please consider opening an issue on the github repository.
   </Accordion>
 </AccordionGroup>

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -21,7 +21,7 @@ description: 'After downloading Wave, get up and running quickly'
     [Desktop Entry]
     Type=Application
     Name=Wave
-    Icon= # IMP todo after PR discussion
+    Icon= /path/to/Wave-linux-*/resources/app/public/waveterm.icns
     Exec=/path/to/Wave-linux-*/Wave
     # setting this to true will launch an extra terminal to run the Wave command
     Terminal=false

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -15,7 +15,7 @@ description: 'After downloading Wave, get up and running quickly'
     2. Change to the Wave directory ```cd waveterm-linux-* ```
     3. Run the application:  ```./Wave```
     
-    While we work on improving the packaging for linux, you can optionally create a ```.desktop``` file , allowing you to launch Wave directly.
+    While we work on improving the packaging for Linux, you can optionally create a `.desktop` file, allowing you to launch Wave directly.
     After doing the above steps, create a file named ```Wave.desktop```, and add the following :
     ```
     [Desktop Entry]

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -16,7 +16,7 @@ description: 'After downloading Wave, get up and running quickly'
     3. Run the application:  ```./Wave```
     
     While we work on improving the packaging for Linux, you can optionally create a `.desktop` file, allowing you to launch Wave directly.
-    After doing the above steps, create a file named `Wave.desktop`, and add the following, modifying the `Exec` path to point to your Wave installation:
+    After doing the above steps, create a file named `Wave.desktop`, and add the following, modifying the `Exec` and `Icon` paths to point to your Wave installation:
     ```
     [Desktop Entry]
     Type=Application

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -26,7 +26,7 @@ description: 'After downloading Wave, get up and running quickly'
     # setting this to true will launch an extra terminal to run the Wave command
     Terminal=false
     ```
-    Then run ```desktop-file-validate Wave.desktop``` which should validate the file. Then, run ```sudo cp Wave.desktop ~/.local/share/applications/Wave.desktop```.
+    Run `desktop-file-validate Wave.desktop` to validate that the desktop entry is correct, then run `sudo cp Wave.desktop ~/.local/share/applications/Wave.desktop` to copy the entry into your application list.
     After restarting, Wave should be visible in application list, and should be launched by clicking the icon.
     While these files and the file scheme is supported by most commonly used desktop environments such as Gnome, Kde, xfce etc. If you come across any issues, please consider opening an issue on the github repository.
   </Accordion>

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -14,6 +14,21 @@ description: 'After downloading Wave, get up and running quickly'
     1. [Download Wave](https://www.commandline.dev/download) and extract the file
     2. Change to the Wave directory ```cd waveterm-linux-* ```
     3. Run the application:  ```./Wave```
+    
+    While we work on improving the packaging for linux, you can optionally create a ```.desktop``` file , allowing you to launch Wave directly.
+    After doing the above steps, create a file named ```Wave.desktop```, and add the following :
+    ```
+    [Desktop Entry]
+    Type=Application
+    Name=Wave
+    Icon= # IMP todo after PR discussion
+    Exec=/path/to/Wave-linux-x64/Wave
+    # setting this to true will launch an extra terminal to run the Wave command
+    Terminal=false
+    ```
+    Then run ```desktop-file-validate Wave.desktop``` which should validate the file. Then, run ```sudo cp Wave.desktop ~/.local/share/applications/Wave.desktop```.
+    After restarting, Wave should be visible in application list, and should be launched by clicking the icon.
+    While these files and the file scheme is supported by most commonly used desktop environments such as Gnome, Kde, xfce etc. If you come across any issues, please consider opening an issue on the github repository.
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
Closes #4 

This adds info about creating and using `.desktop` file for Wave, with which Linux users can directly launch Wave via system tray, and pin it to the dock / add to favorites.

One thing I need help for is the Icon. We need to specify the Icon for the application, giving an absolute path. Currently the github release contains a directory with electron dist. The way I iave set the Icon for myself is a hack, and it uses the path of the dist/<hash>.svg file ; not a good way. I believe the dist is "internal" to electron and can change anytime, so instead can we add the wave icon svg to the directory itself in the building process? That way the path and name would be fixed.