### PR TITLE
Add Telemetry Page

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -71,6 +71,7 @@
             "reference/faq",
             "reference/keyboard",
             "reference/slashcommands",
+            "reference/telemetry",
             "reference/waveshell"
          ]
       }

--- a/reference/faq.mdx
+++ b/reference/faq.mdx
@@ -8,7 +8,7 @@ All of your data, including command history, environment data, and output and al
 
 ## What telemetry do you collect and send?  Can I opt-out?
 
-Wave telemetry is very minimal, anonymized, completely optional, and you can opt out at any time.  In fact we allow you opt-out in the welcome screen when you first run Wave!  If you'd like to change your telemetry setting after the first run, you can using the Wave settings screen (link in the bottom left of the application).  Please consider leaving telemetry on to support us.  We use the telemetry data to track general usage which helps us keep Wave funded and growing.
+Wave telemetry is very minimal, anonymized, completely optional, and you can opt out at any time.  In fact we allow you opt-out in the welcome screen when you first run Wave!  If you'd like to change your telemetry setting after the first run, you can using the Wave settings screen (link in the bottom left of the application).  Please consider leaving telemetry on to support us.  We use the telemetry data to track general usage which helps us keep Wave funded and growing. You can find more info on our telemetry [here](/reference/telemetry).
 
 ## What shells does Wave Terminal support?
 

--- a/reference/telemetry.mdx
+++ b/reference/telemetry.mdx
@@ -38,8 +38,8 @@ When telemetry is active, we collect the following data. It is stored in the `ss
 | FgMinutes | The number of minutes that Waveterm has been in the foreground on a given day. This requires the terminal window to be in focus regardless of user interaction.|
 | OpenMinutes |The number of minutes that Waveterm has been open on a given day. This only requires that the terminal is open, even if the window is out of focus.|
 | ClickShared | See [Deprecated Telemetry References](#deprecated-telemetry-references) |
-| HistoryView | The number of times the user has used the **History** command on a given day. This count includes uses from both the GUI and command line. |
-| BookmarksView | The number of times the user has used the **Bookmarks** command on a given day. |
+| HistoryView | The number of times the user has used the _History_ command on a given day. This count includes uses from both the GUI and command line. |
+| BookmarksView | The number of times the user has used the _Bookmarks_ command on a given day. |
 | NumConns | The total number of connections created on this Waveterm installation. This count includes connections that have been deleted and includes all of the various ways a user can make a connection. Unlike the other data, this always includes the total number of commands that have been created&mdash;not just the ones created each day. |
 | WebShareLimit | See [Deprecated Telemetry References](#deprecated-telemetry-references) |
 | ReinitBashErrors | The number of re-initialization errors that have happened in a bash shell on a given day. |
@@ -57,7 +57,7 @@ In addition to the telemetry data collected, the following is also reported. It 
 | ClientVersion | Which version of Waveterm is installed. |
 | ClientArch | This includes the user's operating system (e.g. linux or darwin) and architecture (e.g. x86_64 or arm64). It does not include data for any Connections at this time. |
 | BuildTime | This serves as a more accurate version number that keeps track of when we built the version. It has no bearing on when that version was installed by you.|
-| DefaultShell | This lists the shell type that Waveterm automatically detects. (e.g. bash or zsh) This is a duplicate entry (also in Telemetry Metadata) that will likely be removed in the future. |
+| DefaultShell | This lists the shell type that Waveterm automatically detects (e.g. bash or zsh). This is a duplicate entry (also in Telemetry Metadata) that will likely be removed in the future. |
 | OSRelease | This lists the version of the operating system the user has installed. |
 
 ## Telemetry Metadata
@@ -74,7 +74,7 @@ Lastly, some data is sent along with the telemetry that describes how to classif
 
 ## When Telemetry is Turned Off
 
-When a user disables telemetry, Waveterm sends a notification that their anonymous Client ID has had its telemetry disabled. This is done with the `pcloud.NoTelemetryInputType` type in the source code. Beyond that, no further information is sent unless telemetry is turned on again. If it is turned on again, the previous 30 days of telemetry will be sent.
+When a user disables telemetry, Waveterm sends a notification that their anonymous _ClientId_ has had its telemetry disabled. This is done with the `pcloud.NoTelemetryInputType` type in the source code. Beyond that, no further information is sent unless telemetry is turned on again. If it is turned on again, the previous 30 days of telemetry will be sent.
 
 ---
 
@@ -83,7 +83,7 @@ When a user disables telemetry, Waveterm sends a notification that their anonymo
 | Name | Description |
 |------|-------------|
 | WebShareLimit | This piece of telemetry existed for a feature from early development that was deprecated before the initial launch. While it is possible that this feature will come back in the future, there are no plans to bring it back at this time. As such, it is currently unused. |
-| ClickShared | The number of times the user has used the **Shared** command on a given day. While the command still exists, it does not actually do anything, so it is marked as deprecated. |
+| ClickShared | The number of times the user has used the _Shared_ command on a given day. While the command still exists, it does not actually do anything, so it is marked as deprecated. |
 | UserId | This is an anonymous UUID created when Waveterm is first launched. It is still sent along with the _ClientId_ when sending regular telemetry messages, but is not used when telemetry is turned off. It as marked as deprecated since it is not used and will be removed from the code in a future update. |
 
 ---

--- a/reference/telemetry.mdx
+++ b/reference/telemetry.mdx
@@ -3,7 +3,9 @@ title: Telemetry
 description: As of v0.7.0
 ---
 
-Waveterm collects some telemetry that we use to generate metrics for funding. The data collected is fairly minimal and can be opted out of at any time. If you would like to turn telemetry on or off, the first opportunity is a button on the initial welcome page. After this, you can find a similar button by opening the settings menu (located at the bottom of the left sidebar). It can alternatively be turned on with the `/telemetry:on` command and turned off with the `/telemetry:off` command.
+Wave Terminal collects telemetry data to help us track feature use, direct future product efforts, and generate aggregate metrics on Wave's popularity and usage.  We do not collect or store any PII (personal identifiable information) and all metric data is only associated with and aggregated using your randomly generated _ClientId_.  You may opt out of collection at any time.
+
+If you would like to turn telemetry on or off, the first opportunity is a button on the initial welcome page. After this, you can find a similar button by opening the settings menu (located at the bottom of the left sidebar). It can alternatively be turned on with the `/telemetry:on` command and turned off with the `/telemetry:off` command.
 
 ---
 
@@ -62,6 +64,7 @@ In addition to the telemetry data collected, the following is also reported. It 
 Lastly, some data is sent along with the telemetry that describes how to classify it. It is stored in the `pcloud.TelemetryInputType` in the source code.
 
 | Name | Description |
+|------|-------------|
 | UserId | See [Deprecated Telemetry References](#deprecated-telemetry-references) |
 | Client Id | This is an anonymous UUID created when Waveterm is first launched. It is used for telemetry and sending prompts to Open AI.
 | CurDay | The current day (in your time zone) when telemetry is sent. It does not include the time of day.
@@ -81,14 +84,19 @@ When a user disables telemetry, Waveterm sends a notification that their anonymo
 |------|-------------|
 | WebShareLimit | This piece of telemetry existed for a feature from early development that was deprecated before the initial launch. While it is possible that this feature will come back in the future, there are no plans to bring it back at this time. As such, it is currently unused. |
 | ClickShared | The number of times the user has used the **Shared** command on a given day. While the command still exists, it does not actually do anything, so it is marked as deprecated. |
-| UserId | This is an anonymous UUID created when Waveterm is first launched. It is still sent along with the ClientId when sending regular telemetry messages, but is not used when telemetry is turned off. It as marked as deprecated since it is not used and will be removed from the code in a future update. |
+| UserId | This is an anonymous UUID created when Waveterm is first launched. It is still sent along with the _ClientId_ when sending regular telemetry messages, but is not used when telemetry is turned off. It as marked as deprecated since it is not used and will be removed from the code in a future update. |
 
 ---
 
 ## A Note on IP Addresses
-As telemetry is sent via http, your IP address will be sent with it as well. We do not collect your IP address or any data associated with it. This admittedly does require an element of trust on your part, but we hope that our level of transparency will convince you that we are being honest about this.
+Telemetry is uploaded via https, which means your IP address is known to the telemetry server.  We **do not** store your IP address in our telemetry table and **do not** associate it with your _ClientId_.
 
 ---
 
 ## Previously Collected Telemetry Data
-While we believe the data we collect with telemetry is fairly minimal, we cannot make that decision for every user. If you ever change your mind about what has been collected previously, you may request that your data be deleted by emailing us at [support@waveterm.dev](mailto:support@waveterm.dev). If you do, we will need your UserId and ClientId to remove it.
+While we believe the data we collect with telemetry is fairly minimal, we cannot make that decision for every user. If you ever change your mind about what has been collected previously, you may request that your data be deleted by emailing us at [support@waveterm.dev](mailto:support@waveterm.dev). If you do, we will need your _ClientId_ to remove it.
+
+---
+
+## Privacy Policy
+For a summary of the above, you can take a look at our [Privacy Policy](https://www.waveterm.dev/privacy).

--- a/reference/telemetry.mdx
+++ b/reference/telemetry.mdx
@@ -1,0 +1,82 @@
+---
+title: Telemetry
+description: As of v0.7.0
+---
+
+Waveterm collects some telemetry that we use to generate metrics for funding. The data collected is fairly minimal and can be opted out of at any time. If you would like to turn telemetry on or off, the first opportunity is a button on the initial welcome page. After this, you can find a similar button by opening the settings menu (located at the bottom of the left sidebar). It can alternatively be turned on with the `/telemetry:on` command and turned off with the `/telemetry:off` command.
+
+---
+
+## Sending Telemetry
+Provided that telemetry is enabled, it is sent 30 seconds after Waveterm is first booted and then again every 8 hours thereafter. It can also be sent in response to a few special cases listed below. When telemetry is sent, it is grouped into individual days as determined by your time zone. Any data from a previous day is marked as `Uploaded` so it will not need to be sent again.
+
+### Sending via Manual Command
+Telemetry can be sent manually with the `/telemetry:send` command if telemetry is active. If telemetry is deactivated, it is still possible to manually send it, but it must be done with the `/telemetry:send force=1` command instead. This does not reset the usual timer for telemetry sends.
+
+### Sending Once Telemetry is Enabled
+As soon as telemetry is enabled, a telemetry update is sent regardless of how long it has been since the last send. This does not reset the usual timer for telemetry sends.
+
+### Notifying that Telemetry is Disabled
+As soon as telemetry is disabled, Waveterm sends a special update that notifies us of this change. See [When Telemetry is Turned Off](#when-telemetry-is-turned-off) for more info. The timer still runs in the background but no data is sent.
+
+
+### When Waveterm is Closed
+Provided that telemetry is enabled, it will be sent when Waveterm is closed.
+
+---
+
+## Telemetry Data
+
+When telemetry is active, we collect the following data. It is stored in the `sstore.TelemetryData` type in the source code.
+
+| Name | Description |
+|------|-------------|
+| NumCommands | The number of Waveterm commands run on a given day. |
+| ActiveMinutes | The number of minutes that the user has actively used Waveterm on a given day. This requires the terminal window to be in focus while the user is actively interacting with it. |
+| FgMinutes | The number of minutes that Waveterm has been in the foreground on a given day. This requires the terminal window to be in focus regardless of user interaction.|
+| OpenMinutes |The number of minutes that Waveterm has been open on a given day. This only requires that the terminal is open, even if the window is out of focus.|
+| HistoryView | The number of times the user has used the **History** command on a given day. This count includes uses from both the GUI and command line. |
+| BookmarksView | The number of times the user has used the **Bookmarks** command on a given day. |
+| NumConns | The total number of connections created on this Waveterm installation. This count includes connections that have been deleted and includes all of the various ways a user can make a connection. Unlike the other data, this always includes the total number of commands that have been created&mdash;not just the ones created each day. |
+| ReinitBashErrors | The number of re-initialization errors that have happened in a bash shell on a given day. |
+| ReinitZshErrors | The number of re-initialization errors that have happened in a zsh shell on a given day. |
+
+## Associated Data
+In addition to the telemetry data collected, the following is also reported. It is stored in the `sstore.ActivityType` type in the source code.
+
+| Name | Description |
+|------|-------------|
+| Day | The date the telemetry is associated with. It does not include the time. |
+| Uploaded | A boolean that indicates if the telemetry for this day is finalized. It is false during the day the telemetry is associated with, but gets set true at the first telemetry upload after that. Once it is true, the data for that particular day will not be sent up with the telemetry any more. |
+| TzName | The code for the timezone the user's OS is reporting (e.g. PST, GMT, JST) |
+| TzOffset | The offset for the timezone the user's OS is reporting (e.g. -08:00, +00:00, +09:00) |
+| ClientVersion | Which version of Waveterm is installed. |
+| ClientArch | This includes the user's operating system (e.g. linux or darwin) and architecture (e.g. x86_64 or arm64). It does not include data for any Connections at this time. |
+| BuildTime | This serves as a more accurate version number that keeps track of when we built the version. It has no bearing on when that version was installed by you.|
+| DefaultShell | This lists the shell type that Waveterm automatically detects. (e.g. bash or zsh) |
+| OSRelease | This lists the version of the operating system the user has installed. |
+
+---
+
+## When Telemetry is Turned Off
+
+When a user disables telemetry, Waveterm sends a notification that their anonymous Client ID has had its telemetry disabled. This is done with the `pcloud.NoTelemetryInputType` type in the source code. Beyond that, no further information is sent unless telemetry is turned on again. If it is turned on again, the previous 30 days of telemetry will be sent.
+
+---
+
+## Deprecated Telemetry References
+
+| Name | Description |
+|------|-------------|
+| WebShareLimit | This piece of telemetry existed for a feature from early development that was deprecated before the initial launch. While it is possible that this feature will come back in the future, there are no plans to bring it back at this time. As such, it is currently unused. |
+| ClickShared | The number of times the user has used the **Shared** command on a given day. While the command still exists, it does not actually do anything, so it is marked as deprecated. |
+
+---
+
+## A Note on IP Addresses
+As telemetry is sent via http, your IP address will be sent with it as well. We do not collect your IP address or any data associated with it. This admittedly does require an element of trust on your part, but we hope that our level of transparency will convince you that we are being honest about this.
+
+---
+
+## Previously Collected Telemetry Data
+While we believe the data we collect with telemetry is fairly minimal, we cannot make that decision for every user. If you ever change your mind about what has been collected previously, you may request that your data be deleted by emailing us at [support@waveterm.dev](mailto:support@waveterm.dev). If you do, we will need your UserId and ClientId to remove it.

--- a/reference/telemetry.mdx
+++ b/reference/telemetry.mdx
@@ -35,9 +35,11 @@ When telemetry is active, we collect the following data. It is stored in the `ss
 | ActiveMinutes | The number of minutes that the user has actively used Waveterm on a given day. This requires the terminal window to be in focus while the user is actively interacting with it. |
 | FgMinutes | The number of minutes that Waveterm has been in the foreground on a given day. This requires the terminal window to be in focus regardless of user interaction.|
 | OpenMinutes |The number of minutes that Waveterm has been open on a given day. This only requires that the terminal is open, even if the window is out of focus.|
+| ClickShared | See [Deprecated Telemetry References](#deprecated-telemetry-references) |
 | HistoryView | The number of times the user has used the **History** command on a given day. This count includes uses from both the GUI and command line. |
 | BookmarksView | The number of times the user has used the **Bookmarks** command on a given day. |
 | NumConns | The total number of connections created on this Waveterm installation. This count includes connections that have been deleted and includes all of the various ways a user can make a connection. Unlike the other data, this always includes the total number of commands that have been created&mdash;not just the ones created each day. |
+| WebShareLimit | See [Deprecated Telemetry References](#deprecated-telemetry-references) |
 | ReinitBashErrors | The number of re-initialization errors that have happened in a bash shell on a given day. |
 | ReinitZshErrors | The number of re-initialization errors that have happened in a zsh shell on a given day. |
 
@@ -53,8 +55,17 @@ In addition to the telemetry data collected, the following is also reported. It 
 | ClientVersion | Which version of Waveterm is installed. |
 | ClientArch | This includes the user's operating system (e.g. linux or darwin) and architecture (e.g. x86_64 or arm64). It does not include data for any Connections at this time. |
 | BuildTime | This serves as a more accurate version number that keeps track of when we built the version. It has no bearing on when that version was installed by you.|
-| DefaultShell | This lists the shell type that Waveterm automatically detects. (e.g. bash or zsh) |
+| DefaultShell | This lists the shell type that Waveterm automatically detects. (e.g. bash or zsh) This is a duplicate entry (also in Telemetry Metadata) that will likely be removed in the future. |
 | OSRelease | This lists the version of the operating system the user has installed. |
+
+## Telemetry Metadata
+Lastly, some data is sent along with the telemetry that describes how to classify it. It is stored in the `pcloud.TelemetryInputType` in the source code.
+
+| Name | Description |
+| UserId | See [Deprecated Telemetry References](#deprecated-telemetry-references) |
+| Client Id | This is an anonymous UUID created when Waveterm is first launched. It is used for telemetry and sending prompts to Open AI.
+| CurDay | The current day (in your time zone) when telemetry is sent. It does not include the time of day.
+| DefaultShell | This lists the shell type that Waveterm automatically detects. (e.g. bash or zsh) |
 
 ---
 
@@ -70,6 +81,7 @@ When a user disables telemetry, Waveterm sends a notification that their anonymo
 |------|-------------|
 | WebShareLimit | This piece of telemetry existed for a feature from early development that was deprecated before the initial launch. While it is possible that this feature will come back in the future, there are no plans to bring it back at this time. As such, it is currently unused. |
 | ClickShared | The number of times the user has used the **Shared** command on a given day. While the command still exists, it does not actually do anything, so it is marked as deprecated. |
+| UserId | This is an anonymous UUID created when Waveterm is first launched. It is still sent along with the ClientId when sending regular telemetry messages, but is not used when telemetry is turned off. It as marked as deprecated since it is not used and will be removed from the code in a future update. |
 
 ---
 


### PR DESCRIPTION
This adds a description of what telemetry we collect and when we send it. It also goes into detail about some of the inner workings of the telemetry system and what happens when it is disabled.